### PR TITLE
feat(sync): Allow users to mark files as hidden

### DIFF
--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/glass-cms/glasscms/internal/parser"
 	"github.com/glass-cms/glasscms/internal/sourcer/fs"
 	"github.com/glass-cms/glasscms/internal/sync"
 	"github.com/glass-cms/glasscms/pkg/api"
@@ -214,7 +215,7 @@ func TestSyncer_Sync(t *testing.T) {
 			sourcer, err := fs.NewSourcer("../../docs/commands")
 			require.NoError(t, err)
 
-			syncer := sync.NewSyncer(sourcer, client, log.NoopLogger())
+			syncer := sync.NewSyncer(sourcer, client, log.NoopLogger(), parser.Config{})
 
 			// Act
 			err = syncer.Sync(context.Background(), tt.livemode)


### PR DESCRIPTION
# Content Visibility Control

Added the ability to filter content during synchronization based on front matter properties.

- **New flags**:
  - `--hidden-property`: Specifies which front matter property determines visibility
  - `--hidden-value`: Controls whether truthy (true) or falsy (false) values indicate hidden content

**Examples:**
```bash
# Skip items where draft=true
glasscms sync filesystem /content --hidden-property "draft" --hidden-value true

# Skip items where published=false
glasscms sync filesystem /content --hidden-property "published" --hidden-value false
```

This enables maintaining draft and published content in the same repository while controlling what gets synchronized to the server.

