### PR TITLE
fix: Update semver regex to be bash-compatible in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,8 @@ jobs:
         echo "VERSION_NO_V=${VERSION#v}" >> $GITHUB_OUTPUT
         
         # Validate semantic version format using regex from semver.org
-        if [[ ! "$VERSION" =~ ^v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*|[0-9a-zA-Z-]+)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*|[0-9a-zA-Z-]+))*)|(-?(?:[0-9a-zA-Z-]+\.)*[0-9a-zA-Z-]+))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$ ]]; then
+        VERSION_NO_PREFIX=${VERSION#v}
+        if [[ ! "$VERSION_NO_PREFIX" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*))?(\+([0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*))?$ ]]; then
           echo "Error: Version '$VERSION' is not a valid semantic version"
           echo "Expected format: v1.0.0, v1.0.0-alpha.1, v1.0.0+build.1, etc."
           exit 1


### PR DESCRIPTION
## Summary
- Fixes the release workflow regex validation that was causing v0.1.0 to fail
- Replaces PCRE syntax `(?:...)` with bash-compatible regex
- Strips 'v' prefix before validation to properly handle version formats

## Problem
The v0.1.0 release failed with:
```
Error: Version 'v0.1.0' is not a valid semantic version
Expected format: v1.0.0, v1.0.0-alpha.1, v1.0.0+build.1, etc.
```

## Solution
- Use bash-compatible regex without PCRE syntax
- Strip the 'v' prefix before validation: `VERSION_NO_PREFIX=${VERSION#v}`
- Apply the semver.org regex to the version without prefix

## Test plan
- [x] Updated regex syntax to be bash-compatible
- [x] After merge, delete and recreate v0.1.0 tag to test release workflow

🤖 Generated with [Claude Code](https://claude.ai/code)