### PR TITLE
feat: Add ignore patterns support for filesystem sourcer

### DIFF
--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -122,7 +122,7 @@ func (c *ConvertCommand) Execute(_ *cobra.Command, args []string) error {
 		return err
 	}
 
-	fileSystemSourcer, err := fs.NewSourcer(sourcePath)
+	fileSystemSourcer, err := fs.NewSourcer(sourcePath, nil)
 	if err != nil {
 		return err
 	}

--- a/cmd/sync_test.go
+++ b/cmd/sync_test.go
@@ -18,3 +18,58 @@ func Test_SyncCommandURLValidation(t *testing.T) {
 	err := command.Command.Execute()
 	require.Error(t, err)
 }
+
+func Test_parseIgnorePatterns(t *testing.T) {
+	tests := map[string]struct {
+		input    string
+		expected []string
+	}{
+		"empty patterns - sync all content": {
+			input:    "",
+			expected: nil,
+		},
+		"ignore template folder": {
+			input:    "Templates",
+			expected: []string{"Templates"},
+		},
+		"ignore common obsidian folders": {
+			input:    ".obsidian,.trash,Templates,Daily Notes",
+			expected: []string{".obsidian", ".trash", "Templates", "Daily Notes"},
+		},
+		"ignore folders with spaces in names": {
+			input:    "Daily Notes, Meeting Notes , Project Archive",
+			expected: []string{"Daily Notes", "Meeting Notes", "Project Archive"},
+		},
+		"ignore drafts and private folders": {
+			input:    "Drafts,,Private,  ,Archive",
+			expected: []string{"Drafts", "Private", "Archive"},
+		},
+		"whitespace only pattern": {
+			input:    "   ",
+			expected: nil,
+		},
+		"malformed comma pattern": {
+			input:    ",,,",
+			expected: nil,
+		},
+		"ignore hidden and temporary folders": {
+			input:    ".*,*temp*,*draft*,*backup*",
+			expected: []string{".*", "*temp*", "*draft*", "*backup*"},
+		},
+		"real obsidian vault structure": {
+			input:    ".obsidian, .trash, Templates, Daily Notes, *.tmp, Archive",
+			expected: []string{".obsidian", ".trash", "Templates", "Daily Notes", "*.tmp", "Archive"},
+		},
+		"content management workflow": {
+			input:    "Inbox,Drafts,Private,Admin,*.conflict*",
+			expected: []string{"Inbox", "Drafts", "Private", "Admin", "*.conflict*"},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			result := cmd.ParseIgnorePatterns(tt.input)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/internal/sourcer/fs/fs_test.go
+++ b/internal/sourcer/fs/fs_test.go
@@ -58,9 +58,9 @@ func TestFileSystemSourcer(t *testing.T) {
 
 	// Arrange.
 	fileData := []testFile{
-		{content: "file 1", depth: 0, pattern: "*.md"},
-		{content: "file 2", depth: 0, pattern: "*.md"},
-		{content: "file 3", depth: 0, pattern: "*.md"},
+		{content: "# Daily Note\nToday's thoughts...", depth: 0, pattern: "*.md"},
+		{content: "# Meeting Notes\nProject discussion...", depth: 0, pattern: "*.md"},
+		{content: "# Article Draft\nContent for blog...", depth: 0, pattern: "*.md"},
 	}
 
 	tempDir, err := createTempDirWithFiles(fileData)
@@ -69,7 +69,7 @@ func TestFileSystemSourcer(t *testing.T) {
 	}
 	defer os.RemoveAll(tempDir)
 
-	src, err := fs.NewSourcer(tempDir)
+	src, err := fs.NewSourcer(tempDir, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -108,43 +108,43 @@ func TestFileSystemSourcer_Size(t *testing.T) {
 		input []testFile
 		want  int
 	}{
-		"no files": {
+		"empty vault": {
 			input: []testFile{},
 			want:  0,
 		},
-		"one markdown file": {
-			input: []testFile{{content: "file 1", depth: 0, pattern: "*.md"}},
+		"single note": {
+			input: []testFile{{content: "# Daily Note\nMy thoughts today...", depth: 0, pattern: "*.md"}},
 			want:  1,
 		},
-		"multiple markdown files": {
+		"multiple notes in vault": {
 			input: []testFile{
-				{content: "file 1", depth: 0, pattern: "*.md"},
-				{content: "file 2", depth: 0, pattern: "*.md"},
-				{content: "file 3", depth: 0, pattern: "*.md"},
+				{content: "# Project Planning\nIdeas for the project...", depth: 0, pattern: "*.md"},
+				{content: "# Meeting Notes\nDiscussion points...", depth: 0, pattern: "*.md"},
+				{content: "# Research Article\nFindings and analysis...", depth: 0, pattern: "*.md"},
 			},
 			want: 3,
 		},
-		"multiple markdown files with depth": {
+		"nested vault structure": {
 			input: []testFile{
-				{content: "file 1", depth: 1, pattern: "*.md"},
-				{content: "file 2", depth: 2, pattern: "*.md"},
-				{content: "file 3", depth: 3, pattern: "*.md"},
+				{content: "# Home\nWelcome to my vault", depth: 1, pattern: "*.md"},
+				{content: "# Projects Overview\nCurrent projects...", depth: 2, pattern: "*.md"},
+				{content: "# Archive Note\nOld content...", depth: 3, pattern: "*.md"},
 			},
 			want: 3,
 		},
-		"non-markdown files": {
+		"non-content files ignored": {
 			input: []testFile{
-				{content: "file 1", depth: 0, pattern: "*.txt"},
-				{content: "file 2", depth: 0, pattern: "*.txt"},
-				{content: "file 3", depth: 0, pattern: "*.txt"},
+				{content: "config data", depth: 0, pattern: "*.json"},
+				{content: "image data", depth: 0, pattern: "*.png"},
+				{content: "text file", depth: 0, pattern: "*.txt"},
 			},
 			want: 0,
 		},
-		"mixed files": {
+		"mixed content types": {
 			input: []testFile{
-				{content: "file 1", depth: 0, pattern: "*.md"},
-				{content: "file 2", depth: 0, pattern: "*.txt"},
-				{content: "file 3", depth: 0, pattern: "*.md"},
+				{content: "# Note\nContent here...", depth: 0, pattern: "*.md"},
+				{content: "config", depth: 0, pattern: "*.json"},
+				{content: "# Another Note\nMore content...", depth: 0, pattern: "*.md"},
 			},
 			want: 2,
 		},
@@ -161,7 +161,7 @@ func TestFileSystemSourcer_Size(t *testing.T) {
 			}
 			defer os.RemoveAll(tempDir)
 
-			sourcer, err := fs.NewSourcer(tempDir)
+			sourcer, err := fs.NewSourcer(tempDir, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -175,7 +175,7 @@ func TestFileSystemSourcer_Size(t *testing.T) {
 func TestIsValidFileSystemSource(t *testing.T) {
 	t.Parallel()
 
-	fp, err := createTempDirWithFiles([]testFile{{content: "file 1", depth: 0, pattern: "*.md"}})
+	fp, err := createTempDirWithFiles([]testFile{{content: "# Welcome\nMy knowledge vault", depth: 0, pattern: "*.md"}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -183,4 +183,158 @@ func TestIsValidFileSystemSource(t *testing.T) {
 
 	require.NoError(t, fs.IsValidFileSystemSource(fp))
 	require.Error(t, fs.IsValidFileSystemSource("non-existent"))
+}
+
+func TestFileSystemSourcer_IgnorePatterns(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		files          []testFile
+		ignorePatterns []string
+		expectedCount  int
+	}{
+		"no ignore patterns - sync all notes": {
+			files: []testFile{
+				{content: "# Home\nWelcome to my vault", depth: 0, pattern: "*.md"},
+				{content: "# Project Note\nDetails about project", depth: 1, pattern: "*.md"},
+				{content: "# Meeting Summary\nMeeting outcomes", depth: 1, pattern: "*.md"},
+			},
+			ignorePatterns: nil,
+			expectedCount:  3,
+		},
+		"ignore templates folder": {
+			files: []testFile{
+				{content: "# Home\nMain vault note", depth: 0, pattern: "*.md"},
+				{content: "# Project Note\nProject details", depth: 1, pattern: "*.md"}, // in dir0/
+			},
+			ignorePatterns: []string{"Templates"},
+			expectedCount:  2, // should not affect existing dirs
+		},
+		"ignore obsidian system folders": {
+			files: []testFile{
+				{content: "# Daily Note\nToday's notes", depth: 0, pattern: "*.md"},
+				{content: "# Archive Note\nOld content", depth: 1, pattern: "*.md"}, // in dir0/
+			},
+			ignorePatterns: []string{".*"},
+			expectedCount:  2, // should not affect non-hidden dirs
+		},
+		"ignore draft folders": {
+			files: []testFile{
+				{content: "# Published Article\nFinished content", depth: 0, pattern: "*.md"},
+				{content: "# Archive Note\nOld notes", depth: 1, pattern: "*.md"}, // in dir0/
+			},
+			ignorePatterns: []string{"Draft*"},
+			expectedCount:  2, // should ignore any Draft folders
+		},
+		"multiple cms ignore patterns": {
+			files: []testFile{
+				{content: "# Home\nMain page", depth: 0, pattern: "*.md"},
+				{content: "# Project Note\nProject info", depth: 1, pattern: "*.md"},
+				{content: "# Deep Archive\nOld content", depth: 2, pattern: "*.md"},
+			},
+			ignorePatterns: []string{"dir1", ".*"},
+			expectedCount:  2, // should ignore dir1 folders and hidden dirs
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			// Create temp directory structure
+			tempDir, err := createTempDirWithFiles(tt.files)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer os.RemoveAll(tempDir)
+
+			// Create sourcer with ignore patterns
+			sourcer, err := fs.NewSourcer(tempDir, tt.ignorePatterns)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Verify expected file count
+			assert.Equal(t, tt.expectedCount, sourcer.Size())
+		})
+	}
+}
+
+func TestFileSystemSourcer_IgnorePatternsWithObsidianVault(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		ignorePatterns []string
+		expectedCount  int
+	}{
+		"ignore templates only": {
+			ignorePatterns: []string{"Templates"},
+			expectedCount:  4, // all except Templates/note-template.md
+		},
+		"ignore obsidian system folders": {
+			ignorePatterns: []string{".*"},
+			expectedCount:  4, // all except .obsidian/config.md
+		},
+		"ignore drafts and templates": {
+			ignorePatterns: []string{"Templates", "Drafts"},
+			expectedCount:  3, // home.md, .obsidian/config.md, Projects/project-a.md
+		},
+		"typical obsidian vault sync": {
+			ignorePatterns: []string{"Templates", ".*", "Drafts"},
+			expectedCount:  2, // home.md, Projects/project-a.md
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			tempDir := createObsidianVaultStructure(t)
+			defer os.RemoveAll(tempDir)
+
+			sourcer, err := fs.NewSourcer(tempDir, tt.ignorePatterns)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			assert.Equal(t, tt.expectedCount, sourcer.Size(), "Expected %d files but got %d", tt.expectedCount, sourcer.Size())
+		})
+	}
+}
+
+// createObsidianVaultStructure creates a realistic Obsidian vault structure for testing.
+func createObsidianVaultStructure(t *testing.T) string {
+	t.Helper()
+
+	tempDir, err := os.MkdirTemp("", "test-ignore")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create Obsidian vault structure
+	dirs := []string{"Templates", ".obsidian", "Drafts", "Projects"}
+	files := map[string]string{
+		"home.md":                    "# Welcome to My Vault\n\nThis is my knowledge base.",
+		"Templates/note-template.md": "# Template\n\n## Date: {{date}}\n\n## Notes:\n\n",
+		".obsidian/config.md":        "Obsidian configuration file",
+		"Drafts/draft-article.md":    "# Draft Article\n\nWork in progress content...",
+		"Projects/project-a.md":      "# Project A\n\n## Status: Active\n\n## Goals:\n- Complete phase 1",
+	}
+
+	// Create directories
+	for _, dir := range dirs {
+		if createErr := os.MkdirAll(filepath.Join(tempDir, dir), 0755); createErr != nil {
+			t.Fatal(createErr)
+		}
+	}
+
+	// Create files
+	for filePath, content := range files {
+		fullPath := filepath.Join(tempDir, filePath)
+		if writeErr := os.WriteFile(fullPath, []byte(content), 0644); writeErr != nil {
+			t.Fatal(writeErr)
+		}
+	}
+
+	return tempDir
 }

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -212,7 +212,7 @@ func TestSyncer_Sync(t *testing.T) {
 			client, err := api.NewClientWithResponses(server.URL)
 			require.NoError(t, err)
 
-			sourcer, err := fs.NewSourcer("../../docs/commands")
+			sourcer, err := fs.NewSourcer("../../docs/commands", nil)
 			require.NoError(t, err)
 
 			syncer, err := sync.NewSyncer(sync.NewSyncID(), sourcer, client, log.NoopLogger(), &parser.Config{})


### PR DESCRIPTION
## Summary
Add `--ignore-patterns` flag to sync command to exclude directories during content synchronization. This enables users to filter out system folders, drafts, and other non-content directories when syncing Obsidian vaults or other content repositories.